### PR TITLE
Resolve on duplicate function for opening a new content form by content type

### DIFF
--- a/ui-tests/cypress/integration/content/attributes-list-nested.spec.js
+++ b/ui-tests/cypress/integration/content/attributes-list-nested.spec.js
@@ -27,7 +27,7 @@ describe('Nested a in List Attribute', () => {
     switch(mode) {
       case 'create':
       default:
-        currentPage = currentPage.getContent().openAddContentPageWithContentType(CONTENT_TYPE_WITH_LIST.name);
+        currentPage = currentPage.getContent().openAddContentPage(CONTENT_TYPE_WITH_LIST.name);
         break;
       case 'edit':
         currentPage = currentPage.getContent().openEditContentPage();

--- a/ui-tests/cypress/integration/content/attributes.spec.js
+++ b/ui-tests/cypress/integration/content/attributes.spec.js
@@ -34,7 +34,7 @@ describe('Content Type Attributes', () => {
     switch(mode) {
       case 'create':
       default:
-        currentPage = currentPage.getContent().openAddContentPageWithContentType(CONTENT_TYPE.name);
+        currentPage = currentPage.getContent().openAddContentPage(CONTENT_TYPE.name);
         break;
       case 'edit':
         currentPage = currentPage.getContent().openEditContentPage();

--- a/ui-tests/cypress/support/pageObjects/content/management/ManagementPage.js
+++ b/ui-tests/cypress/support/pageObjects/content/management/ManagementPage.js
@@ -32,11 +32,6 @@ export default class ManagementPage extends Content {
                .find(htmlElements.ul);
   }
 
-  getAddButtonByLabel(label) {
-    return this.getAddMenu()
-              .find(this.actionOption).contains(label);
-  }
-
   getTable() {
     return this.getContents()
                .find(htmlElements.table);
@@ -61,12 +56,6 @@ export default class ManagementPage extends Content {
     this.getAddContentDropdownList()
         .contains(contentType)
         .click();
-    cy.wait(1000);
-    return new AppPage(AddPage);
-  }
-
-  openAddContentPageWithContentType(contentTypeName) {
-    this.getAddButtonByLabel(contentTypeName).click();
     cy.wait(1000);
     return new AppPage(AddPage);
   }


### PR DESCRIPTION
saw some misuse (yet duplicate) method issue when running cypress tests on my merging cms task