### PR TITLE
ENG-4708 Added test to verify input and retainment of configUi in widget

### DIFF
--- a/ui-tests/cypress/fixtures/data/testConfigUi.json
+++ b/ui-tests/cypress/fixtures/data/testConfigUi.json
@@ -1,0 +1,6 @@
+{
+  "customElement": "my-widget-config",
+  "resources": [
+    "my-widget-config/static/js/test.js"
+  ]
+}


### PR DESCRIPTION
Run the full suite on `awsentando.net` -> results: [LINK](http://smoke.eng-entando.com/logs/cypress_QE/03_25_PM-cypress-test-v1.23/results/index.html)
The results are as expected, with the only unexpected fail being `File Browser > Interactions > Content creation > Creating a folder`, which seems to be related to an old issue that had been opened and then closed because difficult to reproduce ([ENG-3377](https://entando.myjetbrains.com/youtrack/issue/ENG-3377/File-browser-upload-functionality-randomly-returns-to-the-root-folder)).