### PR TITLE
ENG-4775 added test to check the protocol in Entando App pages

### DIFF
--- a/ui-tests/cypress/e2e/portalUI.cy.js
+++ b/ui-tests/cypress/e2e/portalUI.cy.js
@@ -1,3 +1,6 @@
+import {htmlElements} from '../support/pageObjects/WebElement';
+import LoginPage      from '../support/pageObjects/keycloak/LoginPage';
+
 describe('Portal UI', () => {
 
   it('ENG-4181', 'Non-existent URL MUST return 404 status code and Page not found page', () => {
@@ -17,6 +20,97 @@ describe('Portal UI', () => {
       expect(location.pathname).to.eq(`${baseURL}/cypress.page`);
     });
     cy.get('h1').should('have.text', 'Page not found');
+  });
+
+  describe('Protocol for Entando App', () => {
+
+    const httpsUrl = `${Cypress.config('baseUrl').replace('http', 'https')}/*`;
+    const keyCloakCredentials ={
+      username: 'entando_keycloak_admin',
+      password: 'Anp7JH9hgT4BOQ=='
+    };
+
+    beforeEach(() => {
+      cy.wrap(null).as('addedRedirectURI');
+      cy.visit('/', {administrationConsole: true});
+      cy.get(`${htmlElements.div}.welcome-primary-link`).find(htmlElements.a).click();
+      cy.waitForStableDOM();
+      cy.wrap(new LoginPage())
+        .then(page => page.login({username: keyCloakCredentials.username, password: keyCloakCredentials.password}));
+      cy.waitForStableDOM();
+      accessClientOnAdministrationConsole();
+      cy.get(`${htmlElements.input}#newRedirectUri`).type(httpsUrl);
+      cy.get(`${htmlElements.button}.btn-primary[type=submit]`).click();
+      cy.waitForStableDOM();
+      cy.get(`${htmlElements.div}.alert-success`).should('exist').and('be.visible');
+      cy.wrap(true).as('addedRedirectURI');
+    });
+
+    afterEach(() => {
+      cy.get('@addedRedirectURI').then(added => {
+        if (added) {
+          cy.visit('/', {administrationConsole: true});
+          cy.get(`${htmlElements.div}.welcome-primary-link`).find(htmlElements.a).click();
+          cy.waitForStableDOM();
+          accessClientOnAdministrationConsole();
+          cy.get(`${htmlElements.input}#newRedirectUri`).parent().parent().find(`${htmlElements.div}.input-group-btn`)
+            .eq(0).find(`${htmlElements.button}[type=button]`).click();
+          cy.get(`${htmlElements.button}.btn-primary[type=submit]`).click();
+        }
+      });
+    });
+
+    const accessClientOnAdministrationConsole = () => {
+      cy.get(`${htmlElements.div}.sidebar-pf-left`).find(`${htmlElements.div}.nav-category`).eq(0)
+        .children(`${htmlElements.ul}.nav-stacked`)
+        .children(`${htmlElements.li}[data-ng-show="access.queryClients"]`)
+        .children(`${htmlElements.a}`).click();
+      cy.waitForStableDOM();
+      cy.get(`${htmlElements.a}.ng-binding`).contains(Cypress.env('auth_client_id')).click();
+      cy.waitForStableDOM();
+    }
+
+    it([Tag.FEATURE, 'ENG-4775'], 'The right protocol should be used depending on TLS', () => {
+      cy.intercept({
+        method: 'GET',
+        pathname: '/entando-de-app/keycloak.json'
+      }).as('keycloakIntercept')
+      cy.visit('/my_homepage.page', {portalUI: true});
+      cy.waitForStableDOM();
+      cy.wait('@keycloakIntercept').then(interception => {
+        cy.wrap(`${interception.response.url}`)
+          .then(url => {
+            const protocol = new URL(url).protocol;
+            cy.addToReport(() => ({
+              title: 'The protocol being tested is',
+              value: protocol
+            }));
+            const hostName = new URL(url).hostname;
+            const baseUrl = protocol + '//' + hostName;
+            const portalUIUrl = baseUrl + '/entando-de-app/';
+            cy.get('header-fragment').should('have.attr', 'app-url', `${portalUIUrl}`).as('headerFragment');
+            cy.get('@headerFragment').children('.HeaderFragment')
+              .children(htmlElements.a)
+              .children(htmlElements.img).should('have.attr', 'src', `${portalUIUrl}resources/static/img/Entando_light.svg`);
+            cy.get('@headerFragment').find(`${htmlElements.ul}[role="menubar"]`)
+              .find(`${htmlElements.a}.bx--header__menu-item`)
+              .eq(0).should('have.attr', 'href', `${portalUIUrl}en/my_homepage.page`).as('homePageButton');
+            cy.get('@headerFragment').find(`${htmlElements.ul}[role="menubar"]`)
+              .find(`${htmlElements.a}.bx--header__menu-item`)
+              .eq(1).should('have.attr', 'href', `${portalUIUrl}en/about_us.page`).as('aboutUsButton');
+            cy.get('search-bar-widget').should('have.attr', 'action-url', `${portalUIUrl}en/search_result.page`);
+            cy.get('login-button-widget').should('have.attr', 'redirect-url', `${portalUIUrl}en/my_homepage.page`);
+            cy.get('@aboutUsButton').click();
+            cy.waitForStableDOM();
+            cy.location().should(location => {
+              expect(location.protocol).to.eq(protocol);
+              expect(location.origin).to.eq(baseUrl);
+              expect(location.pathname).to.eq('/entando-de-app/en/about_us.page');
+            });
+          });
+      });
+    });
+
   });
 
 });

--- a/ui-tests/cypress/support/command/command.js
+++ b/ui-tests/cypress/support/command/command.js
@@ -5,8 +5,10 @@ import addContext from 'mochawesome/addContext';
 
 import HomePage from '../pageObjects/HomePage';
 
-Cypress.Commands.overwrite('visit', (originalFn, url, options = {portalUI: false}) => {
-  url = options.portalUI ? Cypress.config('portalUIPath') + url : Cypress.config('basePath') + url;
+Cypress.Commands.overwrite('visit', (originalFn, url, options = {portalUI: false, administrationConsole: false, external: false}) => {
+  if (options.portalUI) url = Cypress.config('portalUIPath') + url;
+  else if (options.administrationConsole) url = Cypress.env('auth_base_url') + url;
+  else if (!options.external) url = Cypress.config('basePath') + url;
   return originalFn(url, options);
 });
 


### PR DESCRIPTION
Details about this added test can be found here: [ENG-4775](https://entando.myjetbrains.com/youtrack/issue/ENG-4775/Add-a-Cypress-test-to-check-the-correct-protocol-being-used-in-Entando-App)

A Cypress test run with the `full` tag has been run on the pipeline on aws (apps.autotest.awsentando.net) on 7.2.0-rc1:
[TEST RESULTS](http://smoke.eng-entando.com/logs/cypress_QE/08_33_AM-cypeng4775-v1.23/results/index.html) ([download](http://smoke.eng-entando.com/logs/cypress_QE/08_33_AM-cypeng4775-v1.23/cypress_test.tar.gz))

The results are the same as the full test run of the current release tag of the suite ([LINK](http://smoke.eng-entando.com/logs/cypress_QE/04_31_PM-cypress720rc1-v1.23/results/index.html) for comparison), except for `A user with "group1" permission SHOULD NOT be able to view a page with "administrators" owner group and no join group`, but this fail doesn't appear to be related to the update (it appears to be a random occurrence in which Cypress occasionally doesn't catch the 302 redirect call, before the 401 unauthorized status code from visiting a forbidden page)